### PR TITLE
In case you're interested in some slight changes I've made to your query.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # Ansible Inventory from VMWare
 
 Simple python script which uses PySphere to fill the Ansible inventory from VMWare vCenter.
-
-[Github repository](https://github.com/RaymiiOrg/ansible-vmware)  =
+Originally Cloned from: [Github repository](https://github.com/RaymiiOrg/ansible-vmware)  =
 [Official Website](https://raymii.org/s/software/Ansible__Dynamic_Inventory_From_VMware_vCenter.html)
+
+My fork has added an option to override the strict SSL Cert Validation:
+https://www.python.org/dev/peps/pep-0476/ as well as command line option parsing
+with argparse.
 
 ### Installation
 


### PR DESCRIPTION
Added an option to NOT choke when you're using Self-Signed bogus certs (-n, --no-ssl-verify)
Added argparse command line option handling. No need to hard code in the servername, username, or password. If you don't pass in the password as a command line option, it'll prompt you for it using getpass.getpass. 

Pardon my programming skill, I'm pretty new at it =)
